### PR TITLE
removed deprecated 'uri.encode'

### DIFF
--- a/lib/fluent/plugin/griddb_auth.rb
+++ b/lib/fluent/plugin/griddb_auth.rb
@@ -59,7 +59,9 @@ module Fluent
       res = nil
       begin      
         @last_request_time = Time.now.to_f        
-        res = Net::HTTP.start(uri.host, uri.port) {|http| http.request(req) }
+        res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          http.request(req)
+        end
   
       rescue => e 
         log.warn "Net::HTTP.#{req.method.capitalize} raises exception: #{e.class}, '#{e.message}'"

--- a/lib/fluent/plugin/griddb_auth.rb
+++ b/lib/fluent/plugin/griddb_auth.rb
@@ -47,7 +47,7 @@ module Fluent
     # Create new request
     def create_request(record)
       url = format_url()
-      uri = URI.parse(URI.encode(url))
+      uri = URI.parse(url)
       req = Net::HTTP::Put.new(uri.request_uri)
 	  req.basic_auth(@username, @password)
       set_body(req, record)


### PR DESCRIPTION
newer versions of ruby have deprecated `URI.encode` and causes this plugin to fail